### PR TITLE
fix: downgrade kubescheduler config

### DIFF
--- a/deploy/scheduler.yaml
+++ b/deploy/scheduler.yaml
@@ -7,18 +7,15 @@ data:
   scheduler-config.yaml: |
     apiVersion: kubescheduler.config.k8s.io/v1alpha1
     kind: KubeSchedulerConfiguration
-    profiles:
-      - schedulerName: hwameistor-scheduler
-        plugins:
-          filter:
-            enabled:
-            - name: hwameistor-scheduler-plugin
+    schedulerName: hwameistor-scheduler
     leaderElection:
       leaderElect: true
       lockObjectName: hwameistor-scheduler
-    clientConnection:
-      kubeconfig: /etc/kubernetes/scheduler.conf
-
+      resourceLock: leases
+    plugins:
+      filter:
+        enabled:
+          - name: hwameistor-scheduler-plugin
 ---
 
 apiVersion: apps/v1


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### Why we need this PR:
remove profile field in kubescheduler config(for lower version client-go CRD don't have such field)
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
